### PR TITLE
Correct JSZip.js casing (resolves #7)

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -15,6 +15,6 @@
 <script src=/phosphorus/lib/StackBlur.js></script>
 <script src=/phosphorus/lib/canvg.js></script>
 <script src=/phosphorus/phosphorus.js></script>
-<script src=JSZip.js></script>
+<script src=jszip.js></script>
 <script src=parcel.js></script>
 

--- a/build/index.html
+++ b/build/index.html
@@ -15,5 +15,5 @@
 <script src=/phosphorus/lib/StackBlur.js></script>
 <script src=/phosphorus/lib/canvg.js></script>
 <script src=/phosphorus/phosphorus.js></script>
-<script src=/app/JSZip.js></script>
+<script src=/app/jszip.js></script>
 <script src=tosh.bundle.js></script>


### PR DESCRIPTION
Swaps `JSZip.js` with `jszip.js` in both `index.html` files for case-sensitive filesystems, e.g. Linux.