### PR TITLE
Update node dependency protocol to https, git protocol deprecated

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "codemirror": "^5.25.0",
     "jszip": "^2",
     "moo": "^0.4.2",
-    "nearley": "git://github.com/hardmath123/nearley.git#05e4c47",
-    "nearley-reverse": "git://github.com/tjvr/nearley-reverse.git#f32249d",
-    "v2": "git://github.com/nathan/v2.git#03984d2"
+    "nearley": "https://github.com/hardmath123/nearley.git#05e4c47",
+    "nearley-reverse": "https://github.com/tjvr/nearley-reverse.git#f32249d",
+    "v2": "https://github.com/nathan/v2.git#03984d2"
   },
   "devDependencies": {
     "babel-core": "^6.24.1",


### PR DESCRIPTION
This fix resolves this error seen when following the installation instructions:
```terminal
$ yarn
yarn install v1.22.17
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
error Command failed.
Exit code: 128
Command: git
Arguments: ls-remote --tags --heads git://github.com/hardmath123/nearley.git
Directory: /Users/michael/src/tosh2
Output:
fatal: unable to connect to github.com:
github.com[0: 140.82.113.4]: errno=Operation timed out
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```
This parallels the similar issue here: https://github.com/instructure/canvas-lms/issues/1404